### PR TITLE
Refactor

### DIFF
--- a/fast_DGSEM_block_inversion.py
+++ b/fast_DGSEM_block_inversion.py
@@ -16,52 +16,56 @@ Created on Fri Aug 25 14:07:32 2023
 
 """
 
-import matplotlib.pyplot as plt
+import math
+
 import numpy as np
-
-# -----------------------------------------------------------------------------
-# Parameters
-# -----------------------------------------------------------------------------
-
-p = 2  # Polynomial order
 
 # -----------------------------------------------------------------------------
 # Gauss-Lobatto points and weights / d_min
 # -----------------------------------------------------------------------------
 
-lobatto_points = [
-    [],
-    [-1, 1],
-    [-1, 0, 1],
-    [-1, -np.sqrt(1 / 5), np.sqrt(1 / 5), 1],
-    [-1, -np.sqrt(3 / 7), 0, np.sqrt(3 / 7), 1],
-    [
-        -1,
-        -np.sqrt(1 / 3 + 2 * np.sqrt(7) / 21),
-        -np.sqrt(1 / 3 - 2 * np.sqrt(7) / 21),
-        np.sqrt(1 / 3 - 2 * np.sqrt(7) / 21),
-        np.sqrt(1 / 3 + 2 * np.sqrt(7) / 21),
-        1,
-    ],
-]
+_1OV3 = 1.0 / 3.0
+_1OV6 = 0.5 * _1OV3
+_SQRT1OV5 = math.sqrt(0.2)
+_SQRT3OV7 = math.sqrt(3.0 / 7.0)
+_SQRT7 = math.sqrt(7.0)
+_2SQRT7OV21 = 2.0 * _SQRT7 / 21.0
+LOBATTO_POINTS_BY_ORDER = {
+    1: np.array([-1.0, 1.0]),
+    2: np.array([-1.0, 0.0, 1.0]),
+    3: np.array([-1.0, -_SQRT1OV5, +_SQRT1OV5, 1.0]),
+    4: np.array([-1.0, -_SQRT3OV7, 0.0, +_SQRT3OV7, 1.0]),
+    5: np.array(
+        [
+            -1,
+            -math.sqrt(_1OV3 + _2SQRT7OV21),
+            -math.sqrt(_1OV3 - _2SQRT7OV21),
+            +math.sqrt(_1OV3 - _2SQRT7OV21),
+            +math.sqrt(_1OV3 + _2SQRT7OV21),
+            1,
+        ],
+    ),
+}
 
-lobatto_weights = [
-    [],
-    [1, 1],
-    [1 / 3, 4 / 3, 1 / 3],
-    [1 / 6, 5 / 6, 5 / 6, 1 / 6],
-    [0.1, 49 / 90, 32 / 45, 49 / 90, 0.1],
-    [
-        1 / 15,
-        (14 - np.sqrt(7)) / 30,
-        (14 + np.sqrt(7)) / 30,
-        (14 + np.sqrt(7)) / 30,
-        (14 - np.sqrt(7)) / 30,
-        1 / 15,
-    ],
-]
+_49OV90 = 49.0 / 90.0
+LOBATTO_WEIGHTS_BY_ORDER = {
+    1: np.array([1, 1]),
+    2: np.array([_1OV3, 4.0 * _1OV3, _1OV3]),
+    3: np.array([_1OV6, 5.0 * _1OV6, 5.0 * _1OV6, _1OV6]),
+    4: np.array([0.1, _49OV90, 32.0 / 45.0, _49OV90, 0.1]),
+    5: np.array(
+        [
+            1.0 / 15.0,
+            (14.0 - _SQRT7) / 30.0,
+            (14.0 + _SQRT7) / 30.0,
+            (14.0 + _SQRT7) / 30.0,
+            (14.0 - _SQRT7) / 30.0,
+            1.0 / 15.0,
+        ]
+    ),
+}
 
-d_min = [None, 8, 24, 24 * (1 + np.sqrt(5)), 198.6, 428.8]
+d_min_BY_ORDER = {1: 8, 2: 24, 3: 24 * (1 + np.sqrt(5)), 4: 198.6, 5: 428.8}
 
 # -----------------------------------------------------------------------------
 # Functions
@@ -69,7 +73,15 @@ d_min = [None, 8, 24, 24 * (1 + np.sqrt(5)), 198.6, 428.8]
 
 
 def lagrange_derivative(l, xi, pts):
-    """Derivative of the l-th Lagrange polynomial at the point xi"""
+    """Derivative of the l-th Lagrange polynomial at the point xi
+
+    l: int
+        Index of the desired polynomial
+    xi: float
+        Point at which the derivative is computed
+    pts: np.array
+        Lagrangian points
+    """
     n = len(pts)
     c = 1
     for i in range(0, n):
@@ -87,146 +99,430 @@ def lagrange_derivative(l, xi, pts):
 
 
 def D_matrix(p):
-    """Discrete derivative matrix"""
+    """Discrete derivative matrix
+
+    p: int
+        Polynomial order
+
+    Return:
+        The matrix
+    """
+    points = LOBATTO_POINTS_BY_ORDER[p]
     D = np.zeros((p + 1, p + 1))
     for k in range(0, p + 1):
         for l in range(0, p + 1):
-            D[k][l] = lagrange_derivative(l, lobatto_points[p][k], lobatto_points[p])
+            D[k][l] = lagrange_derivative(l, points[k], points)
     return D
 
 
-def L_matrix(p):
-    A = np.zeros((p + 1, p + 1))
-    A[-1, -1] = 1
-    return np.transpose(D_matrix(p)) - 1 / lobatto_weights[p][p] * A
+def L_matrix(D):
+    """Compute matrix L using relying on matrix D
+
+    D: np.ndarray
+        Derivative matrix
+
+    Return:
+        The matrix
+    """
+    p = D.shape[0] - 1
+    A = np.zeros_like(D)
+    A[-1, -1] = 1.0
+    return D.T - A / LOBATTO_WEIGHTS_BY_ORDER[p][p]
 
 
-# -----------------------------------------------------------------------------
-# Diagonalization of L
-# -----------------------------------------------------------------------------
+def L2d_matrix(D, lambda_x, lambda_y):
+    """Compute the matrix for 2D DGSEM systems
 
-L = L_matrix(p)
+    D: np.ndarray
+        Derivative matrix
+    lambda_x, lambda_y: float
+        Celerity*time step over spatial grid size in, respectively, in x
+        and y direction
 
-# Computation of L eigenvalues and eigenvectors with numpy
-[eigValNp, eigVecNp] = np.linalg.eig(L)
+    Return:
+        The 2D matrix
+    """
+    lbd = lambda_x + lambda_y
 
-# "Analytical" computation of L eigenvalues and eigenvectors
-D = D_matrix(p)
+    I = np.eye(D.shape[0])
+    L = L_matrix(D)
+    L1d = I - 2 * lbd * L
 
-coeff = np.zeros(p + 2)
-coeff[0] = lobatto_weights[p][p]
-for i in range(1, p + 2):
-    coeff[i] = np.linalg.matrix_power(D, i - 1)[p, p]
+    L2d = lambda_x / lbd * np.kron(I, L1d) + lambda_y / lbd * np.kron(L1d, I)
+    return L2d
 
-Psi = np.roots(coeff)  # Eigenvalues
 
-R = np.ones((p + 1, p + 1), dtype="complex_")  # Right eigenvectors matrix
-for i in range(p + 1):
-    for k in range(p):
-        R[k, i] = (
-            -1
-            / lobatto_weights[p][p]
-            * sum(
-                Psi[i] ** (-l - 1) * np.linalg.matrix_power(D, l)[p, k]
-                for l in range(0, p + 1)
-            )
-        )
+def R_matrix(D, psi):
+    """Given the eigenvalues, compute the right-eigen-matrix
 
-print("L eigenval.with numpy: {}".format(eigValNp))
-print("Semi-analytical L eigenval.: {}\n".format(Psi))
+    D: np.ndarray
+        Derivative matrix
+    psi: np.ndarray
+        Eigenvalues
 
-# -----------------------------------------------------------------------------
-# Inversion of L2d
-# -----------------------------------------------------------------------------
+    Return:
+        The right-eigen-matrix
+    """
+    p = D.shape[0] - 1
+    ov_w_p = 1.0 / LOBATTO_WEIGHTS_BY_ORDER[p][p]
+    D_powers = np.stack([np.linalg.matrix_power(D, i) for i in range(0, p + 1)])
+    Psi_powers = np.stack([psi ** (-l - 1) for l in range(p + 1)], axis=1)
+    # Psi_powers = 1. / np.stack([psi ** (l + 1) for l in range (p+1)])
+    R = np.ones_like(D, dtype="complex_")  # Right eigenvectors matrix
+    R[:-1, :] = -np.dot(Psi_powers, D_powers[:, p, :-1]).T * ov_w_p
+    # for i in range(p + 1):
+    #    Psi_i_powers = np.array([psi[i] ** (-l - 1) for l in range(0, p + 1)])
+    #    R[:-1, i] = -np.dot(Psi_i_powers, D_powers[:, p, :-1]) * ov_w_p
+    # #    for k in range(p):
+    # #        R[k, i] = -np.dot(Psi_i_powers, D_powers[:, p, k]) * ov_w_p
+    return R
 
-lbd_x = 1
-lbd_y = 1
-lbd = lbd_x + lbd_y
 
-I = np.eye(p + 1)
-L1d = I - 2 * lbd * L
+def eigen_2D(Psi, lambda_x, lambda_y):
+    """Given the 1D ones, compute the 2D eigen-values
 
-L2d = lbd_x / lbd * np.kron(I, L1d) + lbd_y / lbd * np.kron(L1d, I)
+    Psi: np.ndarray
+        1D eigenvalues
+    lambda_x, lambda_y: float
+        Celerity*time step over spatial grid size in, respectively, in x
+        and y direction
 
-# Diagonal block inversion with numpy
+    Return:
+        np.ndarray with containing the 2D eigenvalues
+    """
+    lbd = lambda_x + lambda_y
 
-M = 1 / 2 * np.diag(lobatto_weights[p])
+    I = np.eye(Psi.shape[0])
+    # Psi_lbd = I - 2 * lbd * np.diag(Psi)
+    Psi_lbd = np.diag(1.0 - 2.0 * lbd * Psi)
+    Psi2d = lambda_x / lbd * np.kron(I, Psi_lbd) + lambda_y / lbd * np.kron(Psi_lbd, I)
+    return Psi2d
 
-L2d_numpyInv = np.dot(np.linalg.inv(np.kron(M, M)), np.linalg.inv(L2d))
 
-# Explicit diagonal block inversion
+def eigen_L_numpy(D):
+    """Using matrix D, compute matrix L, then compute its eigen-values using standard
+    numpy functions
 
-Psi_lbd = I - 2 * lbd * np.diag(Psi)
+    D: np.ndarray
+        Derivative matrix
 
-Psi2d = lbd_x / lbd * np.kron(I, Psi_lbd) + lbd_y / lbd * np.kron(Psi_lbd, I)
+    Return:
+        The eigenvalues
+    """
+    L = L_matrix(D)
+    eigValNp, _ = np.linalg.eig(L)
+    return eigValNp
 
-invR = np.linalg.inv(R)
-invMR = np.dot(np.linalg.inv(M), R)
 
-L2d_explInv = np.dot(
-    np.kron(invMR, invMR), np.dot(np.linalg.inv(Psi2d), np.kron(invR, invR))
-)
+def eigen_L_analytical(D):
+    """Using matrix D, compute matrix L, then compute its eigen-values using standard
+    numpy functions
 
-print(
-    "Verification of diag. block inv. (difference inf. norm between the two methods): {}\n".format(
-        np.linalg.norm(L2d_numpyInv - L2d_explInv)
+    D: np.ndarray
+        Derivative matrix
+
+    Return:
+        The eigenvalues
+    """
+    p = D.shape[0] - 1
+
+    # Storing powers of D: D_powers[i,:,:] is the i-th power of D
+    D_powers = np.stack([np.linalg.matrix_power(D, i) for i in range(0, p + 1)])
+
+    coeff = np.zeros(p + 2)
+    coeff[0] = LOBATTO_WEIGHTS_BY_ORDER[p][p]
+    coeff[1:] = D_powers[:, p, p]
+
+    # Eigenvalues
+    Psi = np.roots(coeff)
+    return Psi
+
+
+def L2d_inversion_numpy(D, M, lambda_x, lambda_y):
+    """Invert 2D systems resulting from DGSEM problems with numpy function
+
+    D: np.ndarray
+        Derivative matrix
+    M: np.ndarray
+        M matrix
+    lambda_x, lambda_y: float
+        Celerity*time step over spatial grid size in, respectively, in x
+        and y direction
+
+    Return:
+        The inverse of the 2D matrix
+    """
+    L2d = L2d_matrix(D, lambda_x, lambda_y)
+
+    return np.dot(np.linalg.inv(np.kron(M, M)), np.linalg.inv(L2d))
+
+
+def L2d_inversion_analytical(D, M, lambda_x, lambda_y):
+    """Invert 2D systems resulting from DGSEM problems with analytical method
+
+    D: np.ndarray
+        Derivative matrix
+    M: np.ndarray
+        M matrix
+    lambda_x, lambda_y: float
+        Celerity*time step over spatial grid size in, respectively, in x
+        and y direction
+
+    Return:
+        The inverse of the 2D matrix
+    """
+    Psi = eigen_L_analytical(D)
+    # Psi = eigen_L_numpy(D)
+
+    Psi2d = eigen_2D(Psi, lambda_x, lambda_y)
+    R = R_matrix(D, Psi)
+    invR = np.linalg.inv(R)
+    invMR = np.dot(np.linalg.inv(M), R)
+
+    return np.dot(
+        np.kron(invMR, invMR), np.dot(np.linalg.inv(Psi2d), np.kron(invR, invR))
     )
-)
 
-# -----------------------------------------------------------------------------
-# Inversion de L2dv
-# -----------------------------------------------------------------------------
 
-L2d0 = L2d + 2 * d_min[p] * lbd * np.kron(I, I)
-Uv = np.concatenate(
-    (
-        lbd_x * np.kron(I, np.array(lobatto_weights[p]).reshape((p + 1, 1))),
-        lbd_y * np.kron(np.array(lobatto_weights[p]).reshape((p + 1, 1)), I),
-    ),
-    axis=1,
-)
-Vv = np.concatenate(
-    (np.kron(I, np.ones((p + 1, 1))), np.kron(np.ones((p + 1, 1)), I)), axis=1
-)
+def L2d_inversion_viscosity_numpy(D, M, lambda_x, lambda_y):
+    """Invert 2D systems resulting from DGSEM problems with graph-viscosity with
+    standard `numpy` functions
 
-L2dV = L2d0 - np.dot(Uv, np.transpose(Vv))
+    p: int
+        Polynomial order
+    D: np.ndarray
+        Derivative matrix
+    M: np.ndarray
+        Mass matrix
+    lambda_x, lambda_y: float
+        Ration between celerity*time step over spatial grid size in, respectively, in x
+        and y direction
 
-# Diagonal block inversion with numpy
+    Return:
+        The inverse of the matrix
+    """
+    p = D.shape[0] - 1
+    lobatto_weights = LOBATTO_WEIGHTS_BY_ORDER[p]
+    d_min = d_min_BY_ORDER[p]
 
-L2dV_numpyInv = np.dot(np.linalg.inv(np.kron(M, M)), np.linalg.inv(L2dV))
+    lbd = lambda_x + lambda_y
 
-# Explicit diagonal block inversion
+    I = np.eye(p + 1)
 
-invL2d0 = np.dot(
-    np.kron(R, R),
-    np.dot(
-        np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)), np.kron(invR, invR)
-    ),
-)
-
-invROmega = np.dot(np.linalg.inv(R), np.array(lobatto_weights[p]).reshape((p + 1, 1)))
-
-Z = np.dot(
-    np.kron(R, R),
-    np.dot(
-        np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)),
-        np.concatenate(
-            (np.kron(lbd_x * invR, invROmega), lbd_y * np.kron(invROmega, invR)), axis=1
+    L2d0 = L2d_matrix(D, lambda_x, lambda_y) + 2 * d_min * lbd * np.kron(I, I)
+    Uv = np.concatenate(
+        (
+            lambda_x * np.kron(I, lobatto_weights.reshape((p + 1, 1))),
+            lambda_y * np.kron(lobatto_weights.reshape((p + 1, 1)), I),
         ),
-    ),
-)
-
-# TODO: check the line below
-# L2dV_explInv = np.dot(np.linalg.inv(np.kron(M, M)), np.dot(np.kron(I, I) + \
-#                np.dot(Z, np.dot(np.linalg.inv(np.eye(2 * p + 2) + np.dot(np.transpose(Vv), Z)), np.transpose(Vv))), invL2d0))
-
-L2dV_explInv = np.dot(
-    np.linalg.inv(np.kron(M, M)),
-    np.dot(np.linalg.inv(np.kron(I, I) - np.dot(Z, np.transpose(Vv))), invL2d0),
-)
-
-print(
-    "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): {}".format(
-        np.linalg.norm(L2dV_numpyInv - L2dV_explInv)
+        axis=1,
     )
-)
+    Vv = np.concatenate(
+        (np.kron(I, np.ones((p + 1, 1))), np.kron(np.ones((p + 1, 1)), I)), axis=1
+    )
+
+    L2dV = L2d0 - np.dot(Uv, np.transpose(Vv))
+
+    # Diagonal block inversion with numpy
+    L2dV_numpyInv = np.dot(np.linalg.inv(np.kron(M, M)), np.linalg.inv(L2dV))
+    return L2dV_numpyInv
+
+
+def L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y):
+    """Invert 2D systems resulting from DGSEM problems with graph-viscosity with
+    analytical formula
+
+    p: int
+        Polynomial order
+    D: np.ndarray
+        Derivative matrix
+    M: np.ndarray
+        Mass matrix
+    lambda_x, lambda_y: float
+        Ration between celerity*time step over spatial grid size in, respectively, in x
+        and y direction
+
+    Return:
+        The inverse of the matrix
+    """
+    p = D.shape[0] - 1
+    lobatto_weights = LOBATTO_WEIGHTS_BY_ORDER[p]
+    d_min = d_min_BY_ORDER[p]
+
+    Psi = eigen_L_analytical(D)
+    # Psi = eigen_L_numpy(D)
+    Psi2d = eigen_2D(Psi, lambda_x, lambda_y)
+    R = R_matrix(D, Psi)
+    invR = np.linalg.inv(R)
+
+    lbd = lambda_x + lambda_y
+
+    I = np.eye(p + 1)
+
+    Vv = np.concatenate(
+        (np.kron(I, np.ones((p + 1, 1))), np.kron(np.ones((p + 1, 1)), I)), axis=1
+    )
+
+    # Explicit diagonal block inversion
+    invPsi2d = np.linalg.inv(Psi2d + 2 * d_min * lbd * np.kron(I, I))
+    invL2d0 = np.dot(np.kron(R, R), np.dot(invPsi2d, np.kron(invR, invR)))
+
+    invROmega = np.dot(invR, lobatto_weights.reshape((p + 1, 1)))
+
+    Z = np.dot(
+        np.kron(R, R),
+        np.dot(
+            invPsi2d,
+            np.concatenate(
+                (
+                    np.kron(lambda_x * invR, invROmega),
+                    lambda_y * np.kron(invROmega, invR),
+                ),
+                axis=1,
+            ),
+        ),
+    )
+
+    # TODO: check the line below
+    # L2dV_explInv = np.dot(
+    #     np.linalg.inv(np.kron(M, M)),
+    #     np.dot(
+    #         np.kron(I, I)
+    #         + np.dot(
+    #             Z,
+    #             np.dot(
+    #                 np.linalg.inv(np.eye(2 * p + 2) + np.dot(np.transpose(Vv), Z)),
+    #                 np.transpose(Vv),
+    #             ),
+    #         ),
+    #         invL2d0,
+    #     ),
+    # )
+
+    L2dV_explInv = np.dot(
+        np.linalg.inv(np.kron(M, M)),
+        np.dot(np.linalg.inv(np.kron(I, I) - np.dot(Z, np.transpose(Vv))), invL2d0),
+    )
+    return L2dV_explInv
+
+
+def compare_eigenvalues_computation(p):
+    """Compare the computation of the eigenvalues of the L matrix with numpy function
+    and analytical formula
+
+    p: int
+        Polynomial order
+
+    Return:
+        The eigenvalues
+    """
+    # Main matrix with derivatives
+    D = D_matrix(p)
+
+    # Computation of L eigenvalues and eigenvectors with numpy
+    eigValNp = eigen_L_numpy(D)
+
+    # "Analytical" computation of L eigenvalues and eigenvectors
+    Psi = eigen_L_analytical(D)
+
+    # print("L eigenval.with numpy: {}".format(eigValNp))
+    # print("Semi-analytical L eigenval.: {}\n".format(Psi))
+    print(
+        "Verification of L eigenvalues (difference inf. norm between the two methods): {}\n".format(
+            np.linalg.norm(eigValNp - Psi)
+        )
+    )
+    return Psi
+
+
+def compare_2D_inversion(p, lambda_x, lambda_y):
+    """Compare standard and fast methods to invert 2D systems resulting from DGSEM problems
+
+    p: int
+        Polynomial order
+    lambda_x, lambda_y: float
+        Ration between celerity*time step over spatial grid size in, respectively, in x
+        and y direction
+
+    Return:
+        The inverse of the 2D matrix
+    """
+
+    lobatto_weights = LOBATTO_WEIGHTS_BY_ORDER[p]
+
+    # Main matrices
+    D = D_matrix(p)
+    M = 0.5 * np.diag(lobatto_weights)
+
+    # Diagonal block inversion with numpy
+    L2d_numpyInv = L2d_inversion_numpy(D, M, lambda_x, lambda_y)
+
+    # Explicit diagonal block inversion
+    L2d_explInv = L2d_inversion_analytical(D, M, lambda_x, lambda_y)
+
+    print(
+        "Verification of diag. block inv. (difference inf. norm between the two methods): {}\n".format(
+            np.linalg.norm(L2d_numpyInv - L2d_explInv)
+        )
+    )
+    return L2d_numpyInv
+
+
+def compare_2D_inversion_viscosity(p, lambda_x, lambda_y):
+    """Compare standard and fast methods to invert 2D systems resulting from DGSEM
+    problems with graph-viscosity
+
+    p: int
+        Polynomial order
+    lambda_x, lambda_y: float
+        Ration between celerity*time step over spatial grid size in, respectively, in x
+        and y direction
+
+    Return:
+        The inverse of the matrix
+    """
+
+    lobatto_weights = LOBATTO_WEIGHTS_BY_ORDER[p]
+
+    # Main matrices
+    D = D_matrix(p)
+    M = 0.5 * np.diag(lobatto_weights)
+
+    L2dV_numpyInv = L2d_inversion_viscosity_numpy(D, M, lambda_x, lambda_y)
+    L2dV_explInv = L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y)
+
+    print(
+        "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): {}".format(
+            np.linalg.norm(L2dV_numpyInv - L2dV_explInv)
+        )
+    )
+    return L2dV_numpyInv
+
+
+if __name__ == "__main__":
+    # -----------------------------------------------------------------------------
+    # Parameters
+    # -----------------------------------------------------------------------------
+
+    # Polynomial order
+    p = 2
+
+    # Celerity*time step over spatial grid size
+    lambda_x, lambda_y = 1.0, 1.0
+
+    # -----------------------------------------------------------------------------
+    # Diagonalization of L
+    # -----------------------------------------------------------------------------
+    compare_eigenvalues_computation(p)
+
+    # -----------------------------------------------------------------------------
+    # Inversion of L2d
+    # -----------------------------------------------------------------------------
+
+    compare_2D_inversion(p, lambda_x, lambda_y)
+
+    # -----------------------------------------------------------------------------
+    # Inversion de L2dv
+    # -----------------------------------------------------------------------------
+
+    compare_2D_inversion_viscosity(p, lambda_x, lambda_y)

--- a/fast_DGSEM_block_inversion.py
+++ b/fast_DGSEM_block_inversion.py
@@ -207,13 +207,15 @@ def eigen_2D(Psi, lambda_x, lambda_y):
     Return:
         np.ndarray with containing the 2D eigenvalues
     """
-    lbd = lambda_x + lambda_y
+    # lbd = lambda_x + lambda_y
 
-    I = np.eye(Psi.shape[0])
-    # Psi_lbd = I - 2 * lbd * np.diag(Psi)
-    Psi_lbd = np.diag(1.0 - 2.0 * lbd * Psi)
-    Psi2d = lambda_x / lbd * np.kron(I, Psi_lbd) + lambda_y / lbd * np.kron(Psi_lbd, I)
-    return Psi2d
+    # I = np.eye(Psi.shape[0])
+    # # Psi_lbd = I - 2 * lbd * np.diag(Psi)
+    # Psi_lbd = np.diag(1.0 - 2.0 * lbd * Psi)
+    # Psi2d = lambda_x / lbd * np.kron(I, Psi_lbd) + lambda_y / lbd * np.kron(Psi_lbd, I)
+    return np.diag(
+        1. - 2. * np.array([lambda_x*p_i + lambda_y*p_j for p_j in Psi for p_i in Psi])
+    )
 
 
 def eigen_L_numpy(D):

--- a/fast_DGSEM_block_inversion.py
+++ b/fast_DGSEM_block_inversion.py
@@ -8,46 +8,70 @@ Created on Fri Aug 25 14:07:32 2023
 
 """
 
-    "Maximum principle preserving time implicit DGSEM 
+    "Maximum principle preserving time implicit DGSEM
     for linear scalar conservation laws"
     R.Milani, F.Renac, J.Ruel
-    
+
     Appendix: Fast DGSEM block inversion
 
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Parameters
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-p = 2 # Polynomial order
+p = 2  # Polynomial order
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Gauss-Lobatto points and weights / d_min
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-lobatto_points = [[], [-1, 1], [-1,0,1], [-1, -np.sqrt(1/5), np.sqrt(1/5), 1],\
-                  [-1, -np.sqrt(3/7), 0, np.sqrt(3/7), 1], [-1, -np.sqrt(1/3 + 2*np.sqrt(7)/21), \
-                   -np.sqrt(1/3 - 2*np.sqrt(7)/21), np.sqrt(1/3 - 2*np.sqrt(7)/21), \
-                   np.sqrt(1/3 + 2*np.sqrt(7)/21), 1]]
+lobatto_points = [
+    [],
+    [-1, 1],
+    [-1, 0, 1],
+    [-1, -np.sqrt(1 / 5), np.sqrt(1 / 5), 1],
+    [-1, -np.sqrt(3 / 7), 0, np.sqrt(3 / 7), 1],
+    [
+        -1,
+        -np.sqrt(1 / 3 + 2 * np.sqrt(7) / 21),
+        -np.sqrt(1 / 3 - 2 * np.sqrt(7) / 21),
+        np.sqrt(1 / 3 - 2 * np.sqrt(7) / 21),
+        np.sqrt(1 / 3 + 2 * np.sqrt(7) / 21),
+        1,
+    ],
+]
 
-lobatto_weights = [[],[1, 1], [1/3, 4/3, 1/3], [1/6, 5/6, 5/6, 1/6],\
-                   [0.1, 49/90, 32/45, 49/90, 0.1], [1/15, (14 - np.sqrt(7))/30,\
-                   (14 + np.sqrt(7))/30, (14 + np.sqrt(7))/30, (14 - np.sqrt(7))/30, 1/15]]
+lobatto_weights = [
+    [],
+    [1, 1],
+    [1 / 3, 4 / 3, 1 / 3],
+    [1 / 6, 5 / 6, 5 / 6, 1 / 6],
+    [0.1, 49 / 90, 32 / 45, 49 / 90, 0.1],
+    [
+        1 / 15,
+        (14 - np.sqrt(7)) / 30,
+        (14 + np.sqrt(7)) / 30,
+        (14 + np.sqrt(7)) / 30,
+        (14 - np.sqrt(7)) / 30,
+        1 / 15,
+    ],
+]
 
 d_min = [None, 8, 24, 24 * (1 + np.sqrt(5)), 198.6, 428.8]
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Functions
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
 
 def lagrange_derivative(l, xi, pts):
-    """ Derivative of the l-th Lagrange polynomial at the point xi """
+    """Derivative of the l-th Lagrange polynomial at the point xi"""
     n = len(pts)
-    c = 1 
+    c = 1
     for i in range(0, n):
         if i != l:
             c *= pts[l] - pts[i]
@@ -56,32 +80,35 @@ def lagrange_derivative(l, xi, pts):
         if i != l:
             t = 1
             for j in range(0, n):
-                if j !=l and j != i:
+                if j != l and j != i:
                     t *= xi - pts[j]
             p += t
     return p / c
 
+
 def D_matrix(p):
-    """ Discrete derivative matrix """
+    """Discrete derivative matrix"""
     D = np.zeros((p + 1, p + 1))
     for k in range(0, p + 1):
         for l in range(0, p + 1):
             D[k][l] = lagrange_derivative(l, lobatto_points[p][k], lobatto_points[p])
-    return D 
+    return D
+
 
 def L_matrix(p):
     A = np.zeros((p + 1, p + 1))
     A[-1, -1] = 1
     return np.transpose(D_matrix(p)) - 1 / lobatto_weights[p][p] * A
 
-#-----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # Diagonalization of L
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 L = L_matrix(p)
 
-# Computation of L eigenvalues and eigenvectors with numpy 
-[eigValNp,eigVecNp] = np.linalg.eig(L)
+# Computation of L eigenvalues and eigenvectors with numpy
+[eigValNp, eigVecNp] = np.linalg.eig(L)
 
 # "Analytical" computation of L eigenvalues and eigenvectors
 D = D_matrix(p)
@@ -89,28 +116,35 @@ D = D_matrix(p)
 coeff = np.zeros(p + 2)
 coeff[0] = lobatto_weights[p][p]
 for i in range(1, p + 2):
-    coeff[i] = np.linalg.matrix_power(D, i - 1)[p,p]
+    coeff[i] = np.linalg.matrix_power(D, i - 1)[p, p]
 
-Psi = np.roots(coeff) # Eigenvalues 
+Psi = np.roots(coeff)  # Eigenvalues
 
-R = np.ones((p + 1, p + 1), dtype = "complex_") # Right eigenvectors matrix
+R = np.ones((p + 1, p + 1), dtype="complex_")  # Right eigenvectors matrix
 for i in range(p + 1):
     for k in range(p):
-        R[k,i] = - 1 / lobatto_weights[p][p] * sum(Psi[i]**(-l-1) * np.linalg.matrix_power(D, l)[p,k] for l in range(0, p + 1))
+        R[k, i] = (
+            -1
+            / lobatto_weights[p][p]
+            * sum(
+                Psi[i] ** (-l - 1) * np.linalg.matrix_power(D, l)[p, k]
+                for l in range(0, p + 1)
+            )
+        )
 
 print("L eigenval.with numpy: {}".format(eigValNp))
 print("Semi-analytical L eigenval.: {}\n".format(Psi))
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Inversion of L2d
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 lbd_x = 1
 lbd_y = 1
-lbd = lbd_x + lbd_y 
+lbd = lbd_x + lbd_y
 
 I = np.eye(p + 1)
-L1d = I - 2 * lbd * L 
+L1d = I - 2 * lbd * L
 
 L2d = lbd_x / lbd * np.kron(I, L1d) + lbd_y / lbd * np.kron(L1d, I)
 
@@ -129,18 +163,31 @@ Psi2d = lbd_x / lbd * np.kron(I, Psi_lbd) + lbd_y / lbd * np.kron(Psi_lbd, I)
 invR = np.linalg.inv(R)
 invMR = np.dot(np.linalg.inv(M), R)
 
-L2d_explInv = np.dot(np.kron(invMR, invMR), np.dot(np.linalg.inv(Psi2d), np.kron(invR, invR)))
+L2d_explInv = np.dot(
+    np.kron(invMR, invMR), np.dot(np.linalg.inv(Psi2d), np.kron(invR, invR))
+)
 
-print("Verification of diag. block inv. (difference inf. norm between the two methods): {}\n".format(np.linalg.norm(L2d_numpyInv-L2d_explInv)))
+print(
+    "Verification of diag. block inv. (difference inf. norm between the two methods): {}\n".format(
+        np.linalg.norm(L2d_numpyInv - L2d_explInv)
+    )
+)
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Inversion de L2dv
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 L2d0 = L2d + 2 * d_min[p] * lbd * np.kron(I, I)
-Uv = np.concatenate((lbd_x * np.kron(I, np.array(lobatto_weights[p]).reshape((p + 1, 1))), \
-                     lbd_y * np.kron(np.array(lobatto_weights[p]).reshape((p + 1, 1)), I)), axis = 1)
-Vv = np.concatenate((np.kron(I, np.ones((p + 1, 1))), np.kron(np.ones((p + 1, 1)), I)), axis = 1)
+Uv = np.concatenate(
+    (
+        lbd_x * np.kron(I, np.array(lobatto_weights[p]).reshape((p + 1, 1))),
+        lbd_y * np.kron(np.array(lobatto_weights[p]).reshape((p + 1, 1)), I),
+    ),
+    axis=1,
+)
+Vv = np.concatenate(
+    (np.kron(I, np.ones((p + 1, 1))), np.kron(np.ones((p + 1, 1)), I)), axis=1
+)
 
 L2dV = L2d0 - np.dot(Uv, np.transpose(Vv))
 
@@ -150,17 +197,36 @@ L2dV_numpyInv = np.dot(np.linalg.inv(np.kron(M, M)), np.linalg.inv(L2dV))
 
 # Explicit diagonal block inversion
 
-invL2d0 = np.dot(np.kron(R, R), np.dot(np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)), np.kron(invR, invR)))
+invL2d0 = np.dot(
+    np.kron(R, R),
+    np.dot(
+        np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)), np.kron(invR, invR)
+    ),
+)
 
 invROmega = np.dot(np.linalg.inv(R), np.array(lobatto_weights[p]).reshape((p + 1, 1)))
 
-Z = np.dot(np.kron(R, R), np.dot(np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)), \
-                                 np.concatenate((np.kron(lbd_x * invR, invROmega), lbd_y * np.kron(invROmega, invR)), axis = 1)))
+Z = np.dot(
+    np.kron(R, R),
+    np.dot(
+        np.linalg.inv(Psi2d + 2 * d_min[p] * lbd * np.kron(I, I)),
+        np.concatenate(
+            (np.kron(lbd_x * invR, invROmega), lbd_y * np.kron(invROmega, invR)), axis=1
+        ),
+    ),
+)
 
-# TO DO: check the line below
+# TODO: check the line below
 # L2dV_explInv = np.dot(np.linalg.inv(np.kron(M, M)), np.dot(np.kron(I, I) + \
 #                np.dot(Z, np.dot(np.linalg.inv(np.eye(2 * p + 2) + np.dot(np.transpose(Vv), Z)), np.transpose(Vv))), invL2d0))
- 
-L2dV_explInv = np.dot(np.linalg.inv(np.kron(M, M)), np.dot(np.linalg.inv(np.kron(I, I) - np.dot(Z, np.transpose(Vv))), invL2d0))
 
-print("Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): {}".format(np.linalg.norm(L2dV_numpyInv-L2dV_explInv)))
+L2dV_explInv = np.dot(
+    np.linalg.inv(np.kron(M, M)),
+    np.dot(np.linalg.inv(np.kron(I, I) - np.dot(Z, np.transpose(Vv))), invL2d0),
+)
+
+print(
+    "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): {}".format(
+        np.linalg.norm(L2dV_numpyInv - L2dV_explInv)
+    )
+)

--- a/fast_DGSEM_block_inversion.py
+++ b/fast_DGSEM_block_inversion.py
@@ -276,7 +276,16 @@ def L2d_inversion_numpy(D, M, lambda_x, lambda_y):
     )
 
 
-def L2d_inversion_analytical(D, M, lambda_x, lambda_y):
+def L2d_inversion_analytical(
+    D,
+    M,
+    lambda_x,
+    lambda_y,
+    Psi=None,
+    R=None,
+    invR=None,
+    invMR=None,
+):
     """Invert 2D systems resulting from DGSEM problems with analytical method
 
     D: np.ndarray
@@ -290,14 +299,16 @@ def L2d_inversion_analytical(D, M, lambda_x, lambda_y):
     Return:
         The inverse of the 2D matrix
     """
-    Psi = eigen_L_analytical(D)
-    # Psi = eigen_L_numpy(D)
-
+    Psi = Psi if Psi is not None else eigen_L_analytical(D)
     Psi2d = eigen_2D(Psi, lambda_x, lambda_y)
-    R = R_matrix(D, Psi)
-    invR = np.linalg.inv(R)
-    # invMR = np.dot(np.linalg.inv(M), R)
-    invMR = diagonal_matrix_multiply(np.reciprocal(np.diag(M)), R)
+
+    R = R if R is not None else R_matrix(D, Psi)
+    invR = invR if invR is not None else np.linalg.inv(R)
+    invMR = (
+        invMR
+        if invMR is not None
+        else diagonal_matrix_multiply(np.reciprocal(np.diag(M)), R)
+    )
 
     return np.dot(
         # np.kron(invMR, invMR), np.dot(np.linalg.inv(Psi2d), np.kron(invR, invR))
@@ -352,7 +363,15 @@ def L2d_inversion_viscosity_numpy(D, M, lambda_x, lambda_y):
     return L2dV_numpyInv
 
 
-def L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y):
+def L2d_inversion_viscosity_analytical(
+    D,
+    M,
+    lambda_x,
+    lambda_y,
+    Psi=None,
+    R=None,
+    invR=None,
+):
     """Invert 2D systems resulting from DGSEM problems with graph-viscosity with
     analytical formula
 
@@ -373,11 +392,11 @@ def L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y):
     lobatto_weights = LOBATTO_WEIGHTS_BY_ORDER[p]
     d_min = d_min_BY_ORDER[p]
 
-    Psi = eigen_L_analytical(D)
-    # Psi = eigen_L_numpy(D)
+    Psi = Psi if Psi is not None else eigen_L_analytical(D)
     Psi2d = eigen_2D(Psi, lambda_x, lambda_y)
-    R = R_matrix(D, Psi)
-    invR = np.linalg.inv(R)
+
+    R = R if R is not None else R_matrix(D, Psi)
+    invR = invR if invR is not None else np.linalg.inv(R)
 
     lbd = lambda_x + lambda_y
 

--- a/test_fast_dgsem.ipynb
+++ b/test_fast_dgsem.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ed7d25ef-58e7-4898-a23d-7466e8a4d46d",
+   "metadata": {},
+   "source": [
+    "# Fast DGSEM block inversion\n",
+    "\n",
+    "In this notebook, we test the methods analytical formulations for DGSEM-matrix inversion against classical `numpy` tools. We also time them to see which is the most efficient one.\n",
+    "\n",
+    "To test for exactness, we relying on a classical Frobenius norm of the differnce between the proposed analytical formulae and the reference one.\n",
+    "\n",
+    "The performances will be measured with `jupyter` `%%timeit` magic (see the header of the related cells). To compute fair statistics, we use 100 runs (see option `-r 100`) and the default values for loops (10'000): hence, running the notebook might take some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "07b6b385-a346-4177-801c-8a85d686cb1a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import fast_DGSEM_block_inversion as f_dgsem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "36f1ff3e-96be-4dff-a2ed-62ce97be94c2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Polynomial order\n",
+    "p = 2  # Accepted: 1:5 included\n",
+    "\n",
+    "# Celerity*time step over spatial grid size\n",
+    "lambda_x, lambda_y = 1.0, 1.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a208297f-46d6-4def-baf3-00afff61106a",
+   "metadata": {},
+   "source": [
+    "## Exactness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8cb42f4a-1331-446b-b3a5-e50b38b1f216",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification of L eigenvalues (difference inf. norm between the two methods): 2.7599706730399138e-15\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = f_dgsem.compare_eigenvalues_computation(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "acc1d7c5-d896-47a7-b8ba-cd8fb96e6f4d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification of diag. block inv. (difference inf. norm between the two methods): 7.867869324762581e-15\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = f_dgsem.compare_2D_inversion(p, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ecf555ac-278d-4eaa-b22f-58e3d2557afb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): 1.707714654142544e-16\n"
+     ]
+    }
+   ],
+   "source": [
+    "_ = f_dgsem.compare_2D_inversion_viscosity(p, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "476bcb98-ae89-4259-bd4d-b51af0344aef",
+   "metadata": {},
+   "source": [
+    "## Performances\n",
+    "\n",
+    "Setting up needed variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b9a2e277-288b-4152-aa7b-1da28f25acd9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lobatto_weights = f_dgsem.LOBATTO_WEIGHTS_BY_ORDER[p]\n",
+    "\n",
+    "# Derivative matrix\n",
+    "D = f_dgsem.D_matrix(p)\n",
+    "# Mass matrix\n",
+    "M = 0.5 * np.diag(lobatto_weights)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e14f06d6-3fdd-4ffd-88ce-4e6b5a726043",
+   "metadata": {},
+   "source": [
+    "### Eigenvalues\n",
+    "\n",
+    "Reference `numpy` performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3044d71d-07c3-460e-a314-b0317537de8f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "31.1 µs ± 812 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.eigen_L_numpy(D)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0b8724c-4cd5-42dc-bcaf-7ad99a3b56e3",
+   "metadata": {},
+   "source": [
+    "Proposed formula performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f7f865a0-ec69-4373-b14a-6cb00ea4f1aa",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "71.4 µs ± 514 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.eigen_L_analytical(D)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a018db34-8b05-4dda-8dd2-3c724cad5a5e",
+   "metadata": {},
+   "source": [
+    "### 2D matrix inversion\n",
+    "\n",
+    "Reference `numpy` performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "417bb140-d139-4274-a8b0-4aeabd488c13",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "307 µs ± 58.5 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_numpy(D, M, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "509c6f1a-43b5-4707-b72d-ef92205cb351",
+   "metadata": {},
+   "source": [
+    "Proposed formula performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "86eef432-f044-42f7-a814-9e42a6a53e91",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "716 µs ± 136 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_analytical(D, M, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afc7dc7e-102e-400a-a635-f24a301f06de",
+   "metadata": {},
+   "source": [
+    "### 2D matrix with graph viscosity inversion\n",
+    "\n",
+    "Reference `numpy` performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "beb54683-ea0c-467d-9abc-16dc3940d982",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "710 µs ± 84.7 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_viscosity_numpy(D, M, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92e0dd26-a5ab-43e3-b072-17318ffc298d",
+   "metadata": {},
+   "source": [
+    "Proposed formula performances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "5de545d2-e295-40da-b3aa-548adcb03093",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.45 ms ± 189 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_fast_dgsem.ipynb
+++ b/test_fast_dgsem.ipynb
@@ -85,7 +85,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verification of diag. block inv. (difference inf. norm between the two methods): 7.867869324762581e-15\n",
+      "Verification of diag. block inv. (difference inf. norm between the two methods): 8.063148131178543e-15\n",
       "\n"
      ]
     }
@@ -106,7 +106,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): 1.707714654142544e-16\n"
+      "Verification of diag. block inv. with graph visc. (difference inf. norm between the two methods): 2.287689155037822e-16\n"
      ]
     }
    ],
@@ -163,7 +163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "31.1 µs ± 812 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+      "32.1 µs ± 1.74 µs per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
      ]
     }
    ],
@@ -192,7 +192,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "71.4 µs ± 514 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+      "71.7 µs ± 542 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
      ]
     }
    ],
@@ -223,7 +223,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "307 µs ± 58.5 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "263 µs ± 22.3 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -252,7 +252,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "716 µs ± 136 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "315 µs ± 16.3 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -283,7 +283,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "710 µs ± 84.7 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "598 µs ± 55.4 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -312,7 +312,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.45 ms ± 189 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "1.24 ms ± 133 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],

--- a/test_fast_dgsem.ipynb
+++ b/test_fast_dgsem.ipynb
@@ -85,7 +85,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Verification of diag. block inv. (difference inf. norm between the two methods): 8.063148131178543e-15\n",
+      "Verification of diag. block inv. (difference inf. norm between the two methods): 8.060194330240908e-15\n",
       "\n"
      ]
     }
@@ -138,7 +138,12 @@
     "# Derivative matrix\n",
     "D = f_dgsem.D_matrix(p)\n",
     "# Mass matrix\n",
-    "M = 0.5 * np.diag(lobatto_weights)"
+    "M = 0.5 * np.diag(lobatto_weights)\n",
+    "# Eigen-values and -vectors\n",
+    "psi = f_dgsem.eigen_L_analytical(D)\n",
+    "R = f_dgsem.R_matrix(D, psi)\n",
+    "invR = np.linalg.inv(R)\n",
+    "invMR = f_dgsem.diagonal_matrix_multiply(np.reciprocal(np.diag(M)), R)"
    ]
   },
   {
@@ -163,7 +168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "32.1 µs ± 1.74 µs per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+      "31.6 µs ± 1.49 µs per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
      ]
     }
    ],
@@ -192,7 +197,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "71.7 µs ± 542 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+      "71.8 µs ± 1.3 µs per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
      ]
     }
    ],
@@ -223,7 +228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "263 µs ± 22.3 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "233 µs ± 48.1 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -252,13 +257,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "315 µs ± 16.3 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "238 µs ± 3.28 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit -r 100\n",
     "f_dgsem.L2d_inversion_analytical(D, M, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7d0a7d8-2960-43b2-946c-fff22a6ee3cd",
+   "metadata": {},
+   "source": [
+    "Retry by reusing matrices that can be stashed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fe2d622b-86c4-4f73-9830-46d4322e1418",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "66.2 µs ± 473 ns per loop (mean ± std. dev. of 100 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_analytical(D, M, lambda_x, lambda_y, psi, R, invR, invMR)"
    ]
   },
   {
@@ -273,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "beb54683-ea0c-467d-9abc-16dc3940d982",
    "metadata": {
     "tags": []
@@ -283,7 +317,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "598 µs ± 55.4 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "635 µs ± 117 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
@@ -302,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "5de545d2-e295-40da-b3aa-548adcb03093",
    "metadata": {
     "tags": []
@@ -312,13 +346,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.24 ms ± 133 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+      "1.1 ms ± 120 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit -r 100\n",
     "f_dgsem.L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "839d9ac9-d34f-4807-95ae-c15ecdfd4c73",
+   "metadata": {},
+   "source": [
+    "Retry by reusing matrices that can be stashed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "25a1da01-4c7b-41c8-90e3-bd51bba27f3b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "766 µs ± 89.8 µs per loop (mean ± std. dev. of 100 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 100\n",
+    "f_dgsem.L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y, psi, R, invR)"
    ]
   }
  ],

--- a/test_fast_dgsem.py
+++ b/test_fast_dgsem.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+import fast_DGSEM_block_inversion as f_dgsem
+
+
+@pytest.mark.parametrize("p", [2, 3, 4, 5])
+@pytest.mark.parametrize("lambda_x", [1.0, 2.0])
+@pytest.mark.parametrize("lambda_y", [1.0, 1.0])
+class TestMethods:
+    def test_eigen(self, p, lambda_x, lambda_y):
+        # lambda_x/y not useful here, but we keep to have the parametrize
+        D = f_dgsem.D_matrix(p)
+        assert np.allclose(f_dgsem.eigen_L_numpy(D), f_dgsem.eigen_L_analytical(D))
+
+    def test_2D_inversion(self, p, lambda_x, lambda_y):
+        D = f_dgsem.D_matrix(p)
+        M = 0.5 * np.diag(f_dgsem.LOBATTO_WEIGHTS_BY_ORDER[p])
+        assert np.allclose(
+            f_dgsem.L2d_inversion_numpy(D, M, lambda_x, lambda_y),
+            f_dgsem.L2d_inversion_analytical(D, M, lambda_x, lambda_y),
+        )
+
+    def test_2D_inversion_viscosity(self, p, lambda_x, lambda_y):
+        D = f_dgsem.D_matrix(p)
+        M = 0.5 * np.diag(f_dgsem.LOBATTO_WEIGHTS_BY_ORDER[p])
+        assert np.allclose(
+            f_dgsem.L2d_inversion_viscosity_numpy(D, M, lambda_x, lambda_y),
+            f_dgsem.L2d_inversion_viscosity_analytical(D, M, lambda_x, lambda_y),
+        )

--- a/test_fast_dgsem.py
+++ b/test_fast_dgsem.py
@@ -6,7 +6,7 @@ import fast_DGSEM_block_inversion as f_dgsem
 
 @pytest.mark.parametrize("p", [2, 3, 4, 5])
 @pytest.mark.parametrize("lambda_x", [1.0, 2.0])
-@pytest.mark.parametrize("lambda_y", [1.0, 1.0])
+@pytest.mark.parametrize("lambda_y", [1.0])
 class TestMethods:
     def test_eigen(self, p, lambda_x, lambda_y):
         # lambda_x/y not useful here, but we keep to have the parametrize


### PR DESCRIPTION
J'ai modifié le code :

- [Pas important] Formatté avec [_Black_](https://black.readthedocs.io/en/stable/) (il suffit de le télécharger `python3 -m pip install black` et de lancer `python3 -m black fast_DGSEM_block_inversion.py`
- J'ai divisé le code en fonctions unitaires
- J'ai ajouté une fonction `__main__` : ainsi, on peut à la fois 

  - charger le python depuis un autre script `import fast_DGSEM_block_inversion`
  - le lancer directement `python3 fast_DGSEM_block_inversion.py`, c-à-d, exactement ce qu'il faisait avant

- J'ai modifié la façon de calculer la matrice `R`, en essayant d'éviter les boucles `for`. En effet, utiliser de produits `numpy` est significativement plus rapide que des boucles `for`. J'avoue que pour trouver le bon produit j'y suis plutôt allé par essaie-erreur et pas vraiment par logique. Il se peut donc qu'il existe une forme plus naturelle du point de vue théorique.
- J'ai ajouté un notebook jupyter pour faire les tests d'exactitude des deux méthodes et mesurer les performances

Si vous ouvrez le notebook, vous verrez qu'il est déjà "compilé" et vous trouverez que les performances des méthodes explicites sont 2 fois plus lentes que les versions numpy. J'en ai discuté brièvement avec @FlorentRenac . Une possible raison c'est que je recalcule à chaque fois des matrices (surtout des inversion de matrices) qui pourrait être calculées une seule fois au début et puis ré-utilisées.